### PR TITLE
Add link to github in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,3 +93,8 @@ More information on pgAdmin 4 development can be found here;
 
 - https://git.postgresql.org/gitweb/?p=pgadmin4.git;a=summary
 - https://www.pgadmin.org
+
+## Reporting issues and feature requests
+
+Issues and feature requests can be reported on GitHub;
+https://github.com/thaJeztah/pgadmin4-docker


### PR DESCRIPTION
So that people know where to report (Docker store doesn't show links to the source repository :smile:)