### PR TITLE
Add psql, pg_dump, pg_dumpall, and pg_restore (9.6) utilities

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,11 @@ FROM python:2-alpine3.6
 ENV PGADMIN_VERSION=1.6 \
     PYTHONDONTWRITEBYTECODE=1
 
+# Install postgresql tools for backup/restore
+RUN apk add --no-cache postgresql \
+ && cp /usr/bin/psql /usr/bin/pg_dump /usr/bin/pg_dumpall /usr/bin/pg_restore /usr/local/bin/ \
+ && apk del postgresql
+
 RUN apk add --no-cache alpine-sdk postgresql-dev \
  && pip install --upgrade pip \
  && echo "https://ftp.postgresql.org/pub/pgadmin/pgadmin4/v${PGADMIN_VERSION}/pip/pgadmin4-${PGADMIN_VERSION}-py2.py3-none-any.whl" | pip install --no-cache-dir -r /dev/stdin \

--- a/config_distro.py
+++ b/config_distro.py
@@ -66,3 +66,23 @@ UPGRADE_CHECK_ENABLED = False
 # STORAGE_DIR = "/path/to/directory/"
 ##########################################################################
 STORAGE_DIR = os.path.join(DATA_DIR, 'storage')
+
+##########################################################################
+# Default locations for binary utilities (pg_dump, pg_restore etc)
+#
+# These are intentionally left empty in the main config file, but are
+# expected to be overridden by packagers in config_distro.py.
+#
+# A default location can be specified for each database driver ID, in
+# a dictionary. Either an absolute or relative path can be specified.
+# In cases where it may be difficult to know what the working directory
+# is, "$DIR" can be specified. This will be replaced with the path to the
+# top-level pgAdmin4.py file. For example, on macOS we might use:
+#
+# $DIR/../../SharedSupport
+#
+##########################################################################
+DEFAULT_BINARY_PATHS = {
+    "pg":   "/usr/local/bin",
+    "ppas": "/usr/local/bin"
+}


### PR DESCRIPTION
This allows using backup/restore from the UI

Alpine currently provides the 9.6 version of these tools, so can only be used against a PostgreSQL 9.6 server when backing up / restoring.

fixes https://github.com/thaJeztah/pgadmin4-docker/issues/17