### PR TITLE
Store sessions in DATA_DIR instead of /dev/shm

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ This image can be configured at runtime, by setting environment variables;
 
 - `PG_ADMIN_DATA_DIR` directory to use for storing data (defaults to `/pgadmin/`)
 - `PG_ADMIN_PORT` port to listen on (defaults to `5050`)
+- `PG_ADMIN_SESSION_DIR` directory to use for storing server-side sessions (defaults to `/dev/shm/pgAdmin4_session`)
 - `DEBUG` enable debug mode (detaults to `False`)
 
 More information on pgAdmin 4 development can be found here;

--- a/config_distro.py
+++ b/config_distro.py
@@ -45,7 +45,7 @@ DEFAULT_SERVER_PORT = int(os.getenv('PG_ADMIN_PORT', 5050))
 
 SQLITE_PATH = os.path.join(DATA_DIR, 'config', 'pgadmin4.db')
 
-SESSION_DB_PATH = '/dev/shm/pgAdmin4_session'
+SESSION_DB_PATH = os.path.join(DATA_DIR, 'sessions')
 
 ##########################################################################
 # Upgrade checks

--- a/config_distro.py
+++ b/config_distro.py
@@ -45,7 +45,7 @@ DEFAULT_SERVER_PORT = int(os.getenv('PG_ADMIN_PORT', 5050))
 
 SQLITE_PATH = os.path.join(DATA_DIR, 'config', 'pgadmin4.db')
 
-SESSION_DB_PATH = os.path.join(DATA_DIR, 'sessions')
+SESSION_DB_PATH = os.getenv('PG_ADMIN_SESSION_DIR', '/dev/shm/pgAdmin4_session')
 
 ##########################################################################
 # Upgrade checks


### PR DESCRIPTION
Because Docker only allocates 64MB for /dev/shm, with many users
this can fill up relatively fast. Docker can override this with
`--shm-size`, but when using Kubernetes, we are not able to set this
container flag yet...