### PR TITLE
Update pgAdmin 4.18 and Python 3.8

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:2-alpine3.8
+FROM python:3.8-alpine
 
 # create a non-privileged user to use at runtime
 RUN addgroup -g 50 -S pgadmin \
@@ -13,18 +13,19 @@ RUN apk add --no-cache libedit postgresql \
 
 RUN apk add --no-cache postgresql-dev libffi-dev
 
-ENV PGADMIN_VERSION=3.6
+ENV PGADMIN_VERSION=4.18
 ENV PYTHONDONTWRITEBYTECODE=1
 
 RUN apk add --no-cache alpine-sdk linux-headers \
  && pip install --upgrade pip \
  && echo "https://ftp.postgresql.org/pub/pgadmin/pgadmin4/v${PGADMIN_VERSION}/pip/pgadmin4-${PGADMIN_VERSION}-py2.py3-none-any.whl" | pip install --no-cache-dir -r /dev/stdin \
+ && pip install --no-cache-dir --upgrade Flask-WTF==0.14.3 \
  && apk del alpine-sdk linux-headers
 
 EXPOSE 5050
 
-COPY LICENSE config_distro.py /usr/local/lib/python2.7/site-packages/pgadmin4/
+COPY LICENSE config_distro.py /usr/local/lib/python3.8/site-packages/pgadmin4/
 
 USER pgadmin:pgadmin
-CMD ["python", "./usr/local/lib/python2.7/site-packages/pgadmin4/pgAdmin4.py"]
+CMD ["python", "./usr/local/lib/python3.8/site-packages/pgadmin4/pgAdmin4.py"]
 VOLUME /pgadmin/


### PR DESCRIPTION
Update to most recent version of pgAdmin.  
API deprecations in Python package `werkzeug` require `Flask-WTF` upgrade to 0.14.3.
Furthermore, upgrade to Python 3 due to deprecation of Python 2.